### PR TITLE
[Fix] 헤더 버튼 오류 수정

### DIFF
--- a/clientes/package-lock.json
+++ b/clientes/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "@toast-ui/editor": "^3.2.2",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.1.2",

--- a/clientes/package.json
+++ b/clientes/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "@toast-ui/editor": "^3.2.2",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.2",

--- a/clientes/src/App.js
+++ b/clientes/src/App.js
@@ -8,13 +8,11 @@ import Signup from './pages/Signup';
 import Questions from './pages/Questions';
 import QuestionsAsk from './pages/QuestionsAsk';
 import QuestionsId from './pages/QuestionsId';
-import Tags from './pages/Tags';
-import Users from './pages/Users';
 import Home from './pages/Home';
 
 function App() {
   const location = useLocation();
-  const showFooterPaths = ['/', '/questions', '/tags', '/users', '/home'];
+  const showFooterPaths = ['/', '/questions', '/home'];
   // 현재 경로가 showFooterPaths에 속하는지 확인하는 함수
   const showFooter = () => showFooterPaths.includes(location.pathname);
 
@@ -28,8 +26,6 @@ function App() {
         <Route path="/questions" element={<Questions />}></Route>
         <Route path="/questions/ask" element={<QuestionsAsk />}></Route>
         <Route path="/questions/id" element={<QuestionsId />}></Route>
-        <Route path="/tags" element={<Tags />}></Route>
-        <Route path="/users" element={<Users />}></Route>
         <Route path="/home" element={<Home />}></Route>
       </Routes>
       {showFooter() && <Footer />}

--- a/clientes/src/components/Category.js
+++ b/clientes/src/components/Category.js
@@ -1,21 +1,35 @@
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
-const Cartegory = () => {
+const Category = ({ setIsMenuDropdown }) => {
+  const hideCategory = () => {
+    setIsMenuDropdown(false);
+  };
+
+  // props를 받아오고, 작동도 잘되지만.. setIsMenuIcon 상속 오류로 인해 타입 정의
+  Category.propTypes = {
+    setIsMenuDropdown: PropTypes.func.isRequired,
+  };
+
   return (
     <main className="relative">
       <div className=" absolute top-0 w-60 h-auto bg-white drop-shadow-lg pt-6 pb-3 -ml-2 overflow-y-auto">
         <Link to="/">
-          <div className="pl-2 py-1 hover:text-black hover:font-bold">
-            <button>
-              <h1 className="text-sm text-gray-600 ">Home</h1>
-            </button>
-          </div>
+          <button
+            onClick={hideCategory}
+            className="pl-2 py-1 hover:text-black hover:font-bold"
+          >
+            <h1 className="text-sm text-gray-600 ">Home</h1>
+          </button>
         </Link>
         <div className="pl-2 py-1">
           <h1 className="text-xs pt-3 pb-1 text-gray-600">PUBLIC</h1>
           <div className="flex flex-col items-start ">
             <Link to="/questions">
-              <button className="flex items-center py-1 text-sm hover:text-black w-full hover:font-bold">
+              <button
+                onClick={hideCategory}
+                className="flex items-center py-1 text-sm hover:text-black w-full hover:font-bold"
+              >
                 <svg
                   aria-hidden="true"
                   className="svg-icon iconGlobe fill-slate-500"
@@ -28,16 +42,15 @@ const Cartegory = () => {
                 <h1 className="pl-1 text-gray-600">Questions</h1>
               </button>
             </Link>
-            <Link to="/tags">
-              <button className="py-1 text-sm text-left w-full hover:text-black hover:font-bold cursor-not-allowed">
-                <h1 className="pl-6 text-gray-600">Tags</h1>
-              </button>
-            </Link>
-            <Link to="/users">
-              <button className="py-1 text-sm text-left w-full hover:text-black hover:font-bold cursor-not-allowed">
-                <h1 className="pl-6 text-gray-600">Users</h1>
-              </button>
-            </Link>
+
+            <button className="py-1 text-sm text-left w-full hover:text-black hover:font-bold cursor-not-allowed">
+              <h1 className="pl-6 text-gray-600">Tags</h1>
+            </button>
+
+            <button className="py-1 text-sm text-left w-full hover:text-black hover:font-bold cursor-not-allowed">
+              <h1 className="pl-6 text-gray-600">Users</h1>
+            </button>
+
             <button className="py-1 text-sm text-left w-full hover:text-black hover:font-bold cursor-not-allowed">
               <h1 className="pl-6 text-gray-600">Companies</h1>
             </button>
@@ -224,4 +237,4 @@ const Cartegory = () => {
   );
 };
 
-export default Cartegory;
+export default Category;

--- a/clientes/src/components/Header.js
+++ b/clientes/src/components/Header.js
@@ -1,33 +1,51 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import Cartegory from './Cartegory';
+import Category from './Category';
 
 const Header = () => {
-  const [isMenuIcon, setIsMenuIcon] = useState(false);
-  const [dropdownSearch, setDropdownSearch] = useState(false);
+  const [isMenuDropdown, setIsMenuDropdown] = useState(false);
+  const [isSearchDropdown, setIsSearchDropdown] = useState(false);
 
-  const menuIcon = () => {
-    setIsMenuIcon((prevState) => !prevState);
+  const menuDropdown = () => {
+    setIsMenuDropdown((prevState) => !prevState);
   };
-  const veiwDropdown = () => {
-    setDropdownSearch((prevState) => !prevState);
+  const inputDropdown = () => {
+    setIsSearchDropdown((prevState) => !prevState);
   };
 
-  const dropdownRef = useRef(null);
+  const menuRef = useRef(null);
+  const inputRef = useRef(null);
+
   useEffect(() => {
-    const closeDropdown = (event) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-        setDropdownSearch(false);
-        setIsMenuIcon(false);
+    const closeMenuDropdown = (e) => {
+      if (menuRef.current !== null && !menuRef.current.contains(e.target)) {
+        setIsMenuDropdown(false);
       }
     };
 
-    window.addEventListener('mousedown', closeDropdown);
+    if (isMenuDropdown) {
+      window.addEventListener('mousedown', closeMenuDropdown);
+    }
+    return () => {
+      window.removeEventListener('mousedown', closeMenuDropdown);
+    };
+  }, [isMenuDropdown]);
+
+  useEffect(() => {
+    const closeSearchDropdown = (e) => {
+      if (inputRef.current !== null && !inputRef.current.contains(e.target)) {
+        setIsSearchDropdown(false);
+      }
+    };
+
+    if (isSearchDropdown) {
+      window.addEventListener('mousedown', closeSearchDropdown);
+    }
 
     return () => {
-      window.removeEventListener('mousedown', closeDropdown);
+      window.removeEventListener('mousedown', closeSearchDropdown);
     };
-  }, []);
+  }, [isSearchDropdown]);
 
   return (
     <header className="z-50 bg-white w-full h-14 fixed border-b border-t-[3px] border-t-orange-400 px-2">
@@ -35,27 +53,16 @@ const Header = () => {
         <div>
           <button
             className="h-full flex items-center justify-center px-2"
-            onClick={menuIcon}
+            onClick={menuDropdown}
+            ref={menuRef}
           >
-            {isMenuIcon ? (
-              <img
-                src="/images/close.png"
-                alt="메뉴 아이콘"
-                className="h-6 w-6 my-3.5"
-              />
-            ) : (
-              <img
-                src="/images/menu.png"
-                alt="닫기 아이콘"
-                className="h-6 w-6 my-3.5"
-              />
-            )}
+            <img
+              src={isMenuDropdown ? '/images/close.png' : '/images/menu.png'}
+              alt={isMenuDropdown ? '메뉴 아이콘' : '닫기 아이콘'}
+              className="h-6 w-6 my-3.5"
+            />
           </button>
-          {isMenuIcon && (
-            <div ref={dropdownRef}>
-              <Cartegory setIsMenuIcon={setIsMenuIcon} />
-            </div>
-          )}
+          {isMenuDropdown && <Category setIsMenuDropdown={setIsMenuDropdown} />}
         </div>
         <Link to="/">
           <div className="h-full flex items-center cursor-pointer">
@@ -95,7 +102,8 @@ const Header = () => {
           <input
             placeholder="Search..."
             className="border border-zinc-200 py-1 pl-10 rounded-md flex grow text-sm"
-            onClick={veiwDropdown}
+            onClick={inputDropdown}
+            ref={inputRef}
           />
           <img
             className="absolute left-3 color-[#525960]"
@@ -104,11 +112,8 @@ const Header = () => {
           />
 
           {/* 검색창 클릭시 드롭다운 구현 */}
-          {dropdownSearch ? (
-            <div
-              ref={dropdownRef}
-              className="bg-white drop-shadow-sm w-full min-w-max border border-zinc-200 rounded-md flex grow absolute top-10"
-            >
+          {isSearchDropdown && (
+            <div className="bg-white drop-shadow-sm w-full min-w-max border border-zinc-200 rounded-md flex grow absolute top-10">
               <div className="w-full">
                 <div className="flex w-full p-3">
                   <div className="w-full">
@@ -192,8 +197,6 @@ const Header = () => {
                 </div>
               </div>
             </div>
-          ) : (
-            ''
           )}
         </div>
         <Link to="/login">

--- a/clientes/src/components/SideCartegory.js
+++ b/clientes/src/components/SideCartegory.js
@@ -28,16 +28,12 @@ const SideCartegory = () => {
                 <h1 className="pl-1 text-gray-600">Questions</h1>
               </button>
             </Link>
-            <Link to="/tags">
-              <button className="py-1 text-sm text-left w-full hover:text-black hover:font-bold cursor-not-allowed">
-                <h1 className="pl-6 text-gray-600">Tags</h1>
-              </button>
-            </Link>
-            <Link to="/users">
-              <button className="py-1 text-sm text-left w-full hover:text-black hover:font-bold cursor-not-allowed">
-                <h1 className="pl-6 text-gray-600">Users</h1>
-              </button>
-            </Link>
+            <button className="py-1 text-sm text-left w-full hover:text-black hover:font-bold cursor-not-allowed">
+              <h1 className="pl-6 text-gray-600">Tags</h1>
+            </button>
+            <button className="py-1 text-sm text-left w-full hover:text-black hover:font-bold cursor-not-allowed">
+              <h1 className="pl-6 text-gray-600">Users</h1>
+            </button>
             <button className="py-1 text-sm text-left w-full hover:text-black hover:font-bold cursor-not-allowed">
               <h1 className="pl-6 text-gray-600">Companies</h1>
             </button>

--- a/clientes/src/hooks/DropDown.js
+++ b/clientes/src/hooks/DropDown.js
@@ -1,0 +1,30 @@
+import { useEffect, useState, useRef } from 'react';
+
+const useDetectClose = (initialState) => {
+  const [isOpen, setIsOpen] = useState(initialState);
+  const ref = useRef(null);
+
+  const removeHandler = () => {
+    setIsOpen(!isOpen);
+  };
+
+  useEffect(() => {
+    const onClick = (e) => {
+      if (ref.current !== null && !ref.current.contains(e.target)) {
+        setIsOpen(!isOpen);
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('click', onClick);
+    }
+
+    return () => {
+      window.removeEventListener('click', onClick);
+    };
+  }, [isOpen]);
+
+  return [isOpen, ref, removeHandler];
+};
+
+export default useDetectClose;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "axios": "^1.4.0"
+        "axios": "^1.4.0",
+        "prop-types": "^15.8.1"
       }
     },
     "node_modules/asynckit": {
@@ -74,6 +75,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -93,10 +110,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "axios": "^1.4.0"
+    "axios": "^1.4.0",
+    "prop-types": "^15.8.1"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## 카테고리 이동하면 자동 닫힘 기능 구현하기

### 🐛 상송 에러..
- props도 받아오고 작동도 잘 하는데 상속에러 발생..

<br>

### 해결방법
1. npm 설치
```js
npm install prop-types
```

2. 컴포넌트에 import
```js
import PropTypes from 'prop-types';
```

3. props를 타입 정의
```js
Category.propTypes = {
    setIsMenuIcon: PropTypes.func.isRequired,
  };
```

<br>

### 에러 이슈 블로깅 정리
[해결방법 블로깅](https://velog.io/@yebind/React-missing-in-props-validation-%EC%97%90%EB%9F%AC)

<br>

## 🫠메뉴, 검색창 클릭 연결...
- useRef 사용... (🫠🫠🫠`onClick`랑 `ref` 위치 꼭 잘 볼 것...)

## 🐛 이젠 Link가 왜 안되지..