### PR TITLE
[Feat] 메뉴 페이지 전환시 none 기능, 로그인시 전환 기능

### DIFF
--- a/clientes/src/App.js
+++ b/clientes/src/App.js
@@ -2,6 +2,7 @@ import { Routes, Route, useLocation } from 'react-router-dom';
 import './index.css';
 import Main from './pages/Main';
 import Header from './components/Header';
+// import HeaderOn from './components/HeaderOn';
 import Footer from './components/Footer';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
@@ -12,12 +13,19 @@ import Home from './pages/Home';
 
 function App() {
   const location = useLocation();
-  const showFooterPaths = ['/', '/questions', '/home'];
+  const showFooterPaths = [
+    '/',
+    '/questions',
+    '/home',
+    '/questions/ask',
+    '/questions/id',
+  ];
   // 현재 경로가 showFooterPaths에 속하는지 확인하는 함수
   const showFooter = () => showFooterPaths.includes(location.pathname);
 
   return (
     <div className="w-full">
+      {/* <Header /> */}
       <Header />
       <Routes>
         <Route path="/" element={<Main />}></Route>

--- a/clientes/src/components/Category.js
+++ b/clientes/src/components/Category.js
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-const Category = ({ setIsMenuDropdown }) => {
+const Category = ({ setIsMenuDropdown, hideMenu }) => {
   const hideCategory = () => {
     setIsMenuDropdown(false);
   };
@@ -11,9 +11,13 @@ const Category = ({ setIsMenuDropdown }) => {
     setIsMenuDropdown: PropTypes.func.isRequired,
   };
 
+  Category.propTypes = {
+    hideMenu: PropTypes.func.isRequired,
+  };
+
   return (
     <main className="relative">
-      <div className=" absolute top-0 w-60 h-auto bg-white drop-shadow-lg pt-6 pb-3 -ml-2 overflow-y-auto">
+      <div className=" absolute top-14 w-60 h-auto bg-white drop-shadow-lg pt-6 pb-3 -ml-2 overflow-y-auto">
         <Link to="/">
           <button
             onClick={hideCategory}
@@ -25,7 +29,7 @@ const Category = ({ setIsMenuDropdown }) => {
         <div className="pl-2 py-1">
           <h1 className="text-xs pt-3 pb-1 text-gray-600">PUBLIC</h1>
           <div className="flex flex-col items-start ">
-            <Link to="/questions">
+            <Link to="/questions" onClick={hideMenu}>
               <button
                 onClick={hideCategory}
                 className="flex items-center py-1 text-sm hover:text-black w-full hover:font-bold"

--- a/clientes/src/components/Footer.js
+++ b/clientes/src/components/Footer.js
@@ -1,7 +1,7 @@
 const Footer = () => {
   return (
-    <footer className=" bg-gray-900 absolute -bottom-full px-4 pt-8 pb-10 w-full">
-      <div className="flex justify-center">
+    <footer className="relative bottom-0 w-full h-auto mt-20">
+      <div className="flex justify-center bg-gray-900 absolute w-full px-4 pt-8 pb-10">
         {/* 로고 */}
         <div className="pr-6">
           <svg

--- a/clientes/src/components/Header.js
+++ b/clientes/src/components/Header.js
@@ -231,14 +231,14 @@ const Header = () => {
 
         {/* 로그인 버튼 */}
         <Link to="/login">
-          <button className="border border-blue-100 bg-blue-100 px-3 py-1 rounded-md">
+          <button className="border border-blue-100 bg-blue-100 hover:bg-blue-200 px-3 py-1 rounded-md">
             <h1 className="text-sm text-blue-700">Log in</h1>
           </button>
         </Link>
 
         {/* 회원가입 버튼 */}
         <Link to="/signup">
-          <button className="border border-blue-500 bg-blue-500 px-3 py-1 rounded-md ml-1">
+          <button className="border border-blue-500 bg-blue-500 hover:bg-blue-600 px-3 py-1 rounded-md ml-1">
             <h1 className="text-sm text-white">Sign up</h1>
           </button>
         </Link>

--- a/clientes/src/components/HeaderOn.js
+++ b/clientes/src/components/HeaderOn.js
@@ -52,7 +52,7 @@ const HeaderOn = () => {
     <header className="z-50 bg-white w-full h-14 fixed border-b border-t-[3px] border-t-orange-400 px-2">
       <div className="h-full max-w-full w-[80rem] flex items-center justify-center mx-auto my-0">
         <Link to="/">
-          <div className="h-full flex items-center cursor-pointer">
+          <div className="flex items-center cursor-pointer ">
             <svg
               aria-hidden="true"
               className="native svg-icon iconLogoMd px-2"
@@ -241,6 +241,11 @@ const HeaderOn = () => {
             >
               <path d="M15 1H3a2 2 0 0 0-2 2v2h16V3a2 2 0 0 0-2-2ZM1 13c0 1.1.9 2 2 2h8v3l3-3h1a2 2 0 0 0 2-2v-2H1v2Zm16-7H1v4h16V6Z" />
             </svg>
+          </button>
+
+          {/* 로그아웃 버튼 */}
+          <button className="bg-blue-500 hover:bg-blue-600 rounded-md px-3 py-1 ml-1">
+            <span className="text-sm text-white">Log out</span>
           </button>
         </div>
       </div>

--- a/clientes/src/components/HeaderOn.js
+++ b/clientes/src/components/HeaderOn.js
@@ -1,25 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import Category from './Category';
 
-const Header = () => {
+const HeaderOn = () => {
   const [isMenuDropdown, setIsMenuDropdown] = useState(false);
   const [isSearchDropdown, setIsSearchDropdown] = useState(false);
 
-  // 메뉴 아이콘이 특정 사이트에서는 block / none 처리되는 상태
-  const [isHideMenu, setIsHideMenu] = useState(true);
-
-  const hideMenu = () => {
-    setIsHideMenu(false);
-  };
-
-  const showMenu = () => {
-    setIsHideMenu(true);
-  };
-
-  const menuDropdown = () => {
-    setIsMenuDropdown((prevState) => !prevState);
-  };
   const inputDropdown = () => {
     setIsSearchDropdown((prevState) => !prevState);
   };
@@ -66,32 +51,7 @@ const Header = () => {
   return (
     <header className="z-50 bg-white w-full h-14 fixed border-b border-t-[3px] border-t-orange-400 px-2">
       <div className="h-full max-w-full w-[80rem] flex items-center justify-center mx-auto my-0">
-        {/* 카테고리 메뉴 아이콘 */}
-        {isHideMenu && (
-          <div>
-            {isMenuDropdown && (
-              <Category
-                setIsMenuDropdown={setIsMenuDropdown}
-                hideMenu={hideMenu}
-              />
-            )}
-            <button
-              className="h-full flex items-center justify-center px-2"
-              onClick={menuDropdown}
-              ref={menuButtonRef}
-            >
-              <img
-                src={isMenuDropdown ? '/images/close.png' : '/images/menu.png'}
-                alt={isMenuDropdown ? '메뉴 아이콘' : '닫기 아이콘'}
-                className="h-6 w-6 my-3.5"
-              />
-            </button>
-          </div>
-        )}
-
-        {/* 로고 아이콘 */}
-        {/* 로고 아이콘 눌렀을때 로그인전 메인으로 이동할 수 있는 상태 */}
-        <Link to="/" onClick={showMenu}>
+        <Link to="/">
           <div className="h-full flex items-center cursor-pointer">
             <svg
               aria-hidden="true"
@@ -113,20 +73,12 @@ const Header = () => {
           </div>
         </Link>
 
-        {/* About / Products / For Teams */}
         <div className="flex">
-          <h1 className="px-3 py-1.5 text-sm text-[#525960] cursor-pointer">
-            About
-          </h1>
           <h1 className="px-5 py-1.5 text-sm text-[#525960] cursor-pointer">
             Products
           </h1>
-          <h1 className="px-3 py-1.5 text-sm text-[#525960] cursor-pointer">
-            For Teams
-          </h1>
         </div>
 
-        {/* 입력창 */}
         <div className="relative flex grow items-center mx-2 h-7">
           <input
             placeholder="Search..."
@@ -228,23 +180,72 @@ const Header = () => {
             </div>
           )}
         </div>
-
-        {/* 로그인 버튼 */}
-        <Link to="/login">
-          <button className="border border-blue-100 bg-blue-100 px-3 py-1 rounded-md">
-            <h1 className="text-sm text-blue-700">Log in</h1>
+        <div className="flex items-center ">
+          {/* 유저정보 아이콘 */}
+          <button className="flex items-center px-2">
+            <div className="w-6 h-6 bg-yellow-200 rounded-md mx-1" />
+            <span className="font-semibold text-sm mx-1">1</span>
+            <div className="flex items-center mx-1">
+              <span className="text-[6px] text-yellow-500">●</span>
+              <span className="text-yellow-600 text-sm ml-1">1</span>
+            </div>
           </button>
-        </Link>
 
-        {/* 회원가입 버튼 */}
-        <Link to="/signup">
-          <button className="border border-blue-500 bg-blue-500 px-3 py-1 rounded-md ml-1">
-            <h1 className="text-sm text-white">Sign up</h1>
+          {/* INBOX 드롭다운 */}
+          <button className="fill-slate-600 px-2">
+            <svg
+              aria-hidden="true"
+              className="svg-icon iconInbox"
+              width="20"
+              height="18"
+              viewBox="0 0 20 18"
+            >
+              <path d="M4.63 1h10.56a2 2 0 0 1 1.94 1.35L20 10.79V15a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-4.21l2.78-8.44c.25-.8 1-1.36 1.85-1.35Zm8.28 12 2-2h2.95l-2.44-7.32a1 1 0 0 0-.95-.68H5.35a1 1 0 0 0-.95.68L1.96 11h2.95l2 2h6Z" />
+            </svg>
           </button>
-        </Link>
+
+          {/* ACHIEVEMENTS  드롭다운 */}
+          <button className="fill-slate-600 px-2">
+            <svg
+              aria-hidden="true"
+              className="svg-icon iconAchievements"
+              width="18"
+              height="18"
+              viewBox="0 0 18 18"
+            >
+              <path d="M15 2V1H3v1H0v4c0 1.6 1.4 3 3 3v1c.4 1.5 3 2.6 5 3v2H5s-1 1.5-1 2h10c0-.4-1-2-1-2h-3v-2c2-.4 4.6-1.5 5-3V9c1.6-.2 3-1.4 3-3V2h-3ZM3 7c-.5 0-1-.5-1-1V4h1v3Zm8.4 2.5L9 8 6.6 9.4l1-2.7L5 5h3l1-2.7L10 5h2.8l-2.3 1.8 1 2.7h-.1ZM16 6c0 .5-.5 1-1 1V4h1v2Z" />
+            </svg>
+          </button>
+
+          {/* Help 드롭다운 */}
+          <button className="fill-slate-600 px-2">
+            <svg
+              aria-hidden="true"
+              className="svg-icon iconHelp"
+              width="18"
+              height="18"
+              viewBox="0 0 18 18"
+            >
+              <path d="M9 1C4.64 1 1 4.64 1 9c0 4.36 3.64 8 8 8 4.36 0 8-3.64 8-8 0-4.36-3.64-8-8-8Zm.81 12.13c-.02.71-.55 1.15-1.24 1.13-.66-.02-1.17-.49-1.15-1.2.02-.72.56-1.18 1.22-1.16.7.03 1.2.51 1.17 1.23ZM11.77 8c-.59.66-1.78 1.09-2.05 1.97a4 4 0 0 0-.09.75c0 .05-.03.16-.18.16H7.88c-.16 0-.18-.1-.18-.15.06-1.35.66-2.2 1.83-2.88.39-.29.7-.75.7-1.24.01-1.24-1.64-1.82-2.35-.72-.21.33-.18.73-.18 1.1H5.75c0-1.97 1.03-3.26 3.03-3.26 1.75 0 3.47.87 3.47 2.83 0 .57-.2 1.05-.48 1.44Z" />
+            </svg>
+          </button>
+
+          {/* COMMUNITY 드롭다운 */}
+          <button className="fill-slate-600 px-2">
+            <svg
+              aria-hidden="true"
+              className="svg-icon iconStackExchange"
+              width="18"
+              height="18"
+              viewBox="0 0 18 18"
+            >
+              <path d="M15 1H3a2 2 0 0 0-2 2v2h16V3a2 2 0 0 0-2-2ZM1 13c0 1.1.9 2 2 2h8v3l3-3h1a2 2 0 0 0 2-2v-2H1v2Zm16-7H1v4h16V6Z" />
+            </svg>
+          </button>
+        </div>
       </div>
     </header>
   );
 };
 
-export default Header;
+export default HeaderOn;

--- a/clientes/src/pages/Login.js
+++ b/clientes/src/pages/Login.js
@@ -83,7 +83,7 @@ const Login = () => {
               />
             </div>
             <div className="w-full">
-              <button className="w-full bg-blue-500 rounded-md my-4 py-2">
+              <button className="w-full bg-blue-500 hover:bg-blue-600 rounded-md my-4 py-2">
                 <h1 className="text-white">Log in</h1>
               </button>
             </div>
@@ -92,17 +92,19 @@ const Login = () => {
             <div className=" flex w-ful justify-center">
               <h1 className="mr-1.5">Don&rsquo;t have an account?</h1>
               <Link to="/signup">
-                <button className="text-blue-500">Sign up</button>
+                <button className="text-blue-500 hover:text-blue-300">
+                  Sign up
+                </button>
               </Link>
             </div>
             <div className="flex justify-center w-ful mt-3">
               <h1>Are you an employer?</h1>
               <Link to="https://talent.stackoverflow.com/users/login">
-                <button className="text-blue-500 flex items-center w-ful">
+                <button className="text-blue-500 hover:text-blue-300 fill-blue-500 hover:fill-blue-300 flex items-center w-ful">
                   <h1 className="mx-1.5">Sign up on Talent</h1>
                   <svg
                     aria-hidden="true"
-                    className="va-text-bottom sm:d-none svg-icon iconShareSm w-3.5 h-3.5 fill-blue-500"
+                    className="va-text-bottom sm:d-none svg-icon iconShareSm w-3.5 h-3.5 "
                     viewBox="0 0 14 14"
                   >
                     <path d="M5 1H3a2 2 0 0 0-2 2v8c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V9h-2v2H3V3h2V1Zm2 0h6v6h-2V4.5L6.5 9 5 7.5 9.5 3H7V1Z" />

--- a/clientes/src/pages/Main.js
+++ b/clientes/src/pages/Main.js
@@ -29,14 +29,14 @@ const Main = () => {
                     answer theirs
                   </span>
                   <Link to="/signup">
-                    <button className="bg-orange-500 rounded-md px-8 py-3">
-                      <span className="text-white">Join the community</span>
+                    <button className="bg-orange-500 hover:bg-orange-600 rounded-md px-8 py-3">
+                      <span className="text-white ">Join the community</span>
                     </button>
                   </Link>
                   <span className="flex mt-3 text-sm">
                     or{' '}
                     <Link to="/questions">
-                      <p className="underline ml-1 cursor-pointer">
+                      <p className="underline ml-1 cursor-pointer hover:text-orange-600">
                         search content
                       </p>
                     </Link>
@@ -64,7 +64,7 @@ const Main = () => {
                   <span className="text-center mb-5 text-xl">
                     Want a secure, private space for your technical knowledge?
                   </span>
-                  <button className="bg-blue-500 rounded-md px-8 py-3 cursor-not-allowed">
+                  <button className="bg-blue-500 hover:bg-blue-600 rounded-md px-8 py-3 cursor-not-allowed">
                     <span className="text-white">Discover Teams</span>
                   </button>
                 </div>

--- a/clientes/src/pages/Main.js
+++ b/clientes/src/pages/Main.js
@@ -2,9 +2,9 @@ import { Link } from 'react-router-dom';
 
 const Main = () => {
   return (
-    <main className="relative">
+    <main className="relative min-h-screen">
       <section>
-        <div className="max-w-[1950px] p-12 absolute top-14 w-full border ">
+        <div className="max-w-[1950px] p-12 absolute top-14 w-full border">
           <div className="bg-gray-700 rounded-md flex justify-center flex-col p-8 h-full">
             {/* 말풍선 박스 */}
             <div className="flex justify-center">

--- a/clientes/src/pages/Signup.js
+++ b/clientes/src/pages/Signup.js
@@ -50,7 +50,7 @@ const Signup = () => {
             Collaborate and share knowledge with a private group for FREE.
           </span>
           <button className=" -mt-1">
-            <span className="text-blue-500 text-sm">
+            <span className="text-blue-500 hover:text-blue-300 text-sm">
               Get Stack Overflow for Teams free for up to 50 users.
             </span>
           </button>
@@ -130,7 +130,7 @@ const Signup = () => {
               </span>
             </div>
             <div className="w-full">
-              <button className="w-full bg-blue-500 rounded-md my-4 py-2">
+              <button className="w-full bg-blue-500 hover:bg-blue-600 rounded-md my-4 py-2">
                 <h1 className="text-white">Sign up</h1>
               </button>
             </div>
@@ -146,17 +146,19 @@ const Signup = () => {
             <div className=" flex w-ful justify-center">
               <h1 className="mr-1.5">Already have an account?</h1>
               <Link to="/login">
-                <button className="text-blue-500">Log in</button>
+                <button className="text-blue-500 hover:text-blue-300">
+                  Log in
+                </button>
               </Link>
             </div>
             <div className="flex justify-center w-ful mt-3">
               <h1>Are you an employer?</h1>
               <Link to="https://talent.stackoverflow.com/users/login">
-                <button className="text-blue-500 flex items-center w-ful">
+                <button className="text-blue-500 hover:text-blue-300 fill-blue-500 hover:fill-blue-300 flex items-center w-ful">
                   <h1 className="mx-1.5">Sign up on Talent</h1>
                   <svg
                     aria-hidden="true"
-                    className="va-text-bottom sm:d-none svg-icon iconShareSm w-3.5 h-3.5 fill-blue-500"
+                    className="va-text-bottom sm:d-none svg-icon iconShareSm w-3.5 h-3.5 "
                     viewBox="0 0 14 14"
                   >
                     <path d="M5 1H3a2 2 0 0 0-2 2v8c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V9h-2v2H3V3h2V1Zm2 0h6v6h-2V4.5L6.5 9 5 7.5 9.5 3H7V1Z" />


### PR DESCRIPTION
## 🫠메뉴, 검색창 클릭 연결...
- `useRef` 사용... (🫠🫠🫠`onClick`랑 `ref` 위치 꼭 잘 볼 것...)

## 🐛 이젠 Link가 왜 안되지..
- 해결완료 🫠🫠
  - 이것 또한.. useRef...
- 메뉴 버튼에서 카테고리 컴포넌트가 열려 있는 동안에는 클릭 이벤트를 모니터링하여 해당 컴포넌트에도 접근할 수 있도록 코드를 조정🫠
  - `useEffect` 내부의 이벤트 핸들러 함수에서 클릭 이벤트의 타겟 엘리먼트를 체크하면서 추가적인 동작을 수행하도록 변경

<br>

---

<br>

## 🔥 로그인 ver 헤더 구현 완료
  ![Image](https://github.com/codestates-seb/seb45_pre_025/assets/122279587/f20e6dc1-e67d-4541-a992-37e1fc70bfa1)

## ✨문제
### 로그아웃 페이지 어떡하지..?
- 로그아웃 페이지 따로 구현 없이 헤더에 `로그아웃 버튼`을 만들어서 바로 작동하는 로직으로 구현할 예정.


## ✨문제해결
### 로그아웃 버튼 추가
![Image](https://github.com/codestates-seb/seb45_pre_025/assets/122279587/77d63f8e-726b-4dd1-b653-62f7ca2b0938)




## ⚙️기능 예정 
- 로그인 상태일때 전환하도록 구현 예정
<br>

---

<br>

## 🔥카테고리 로그인 후에 메뉴바 none 처리 구현
### 메인창 화면 (헤더 참고)


![Image](https://github.com/codestates-seb/seb45_pre_025/assets/122279587/95815224-5ae6-4cb6-bd53-ab304aeb157a)

<br>

### 질문창 화면 (헤더 참고)


![Image](https://github.com/codestates-seb/seb45_pre_025/assets/122279587/6d4d5a8b-ad16-4e3a-a239-d95922821d6a)

## ⚙️작업 과정
header.js에 `useState`로 메뉴 상태 설정.
- 처음엔 메뉴아이콘에 상태가 `true` 였다가 질문창을 클릭할 경우 `false`로 변경되어서 안보이게 구현.
- 헤더 컴포넌트 안에 카테고리 컴포넌트가 있어서 상태 변화 함수를 상속 시켜줌.
- 상속 시켜 줌으로서, category.js에서도 `useState` 사용이 가능해짐

<br>

## 💅CSS 기능 추가
- 버튼, 텍스트 hover시 color 전환